### PR TITLE
Style <text> elements with dominant-baseline

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -5,7 +5,7 @@ var fs = require('fs')
 var header = [
     '<svg width="120" height="19" xmlns="http://www.w3.org/2000/svg">'
   , '<style type="text/css">',
-  , 'text{alignment-baseline:middle;font-family:Arial,sans-serif;font-size:10px}'
+  , 'text{dominant-baseline:middle;font-family:Arial,sans-serif;font-size:10px}'
   , '</style>'
 ].join('')
 var footer = '</svg>'


### PR DESCRIPTION
According to the [spec][1], the `alignment-baseline` property only applies to the `<tspan>`, `<tref>`, `<altGlyph>` and `<textPath>` elements. For `<text>` elements there is the [`dominant-baseline` property][2].

Fixes #3

  [1]: https://www.w3.org/TR/SVG/text.html#AlignmentBaselineProperty
  [2]: https://www.w3.org/TR/SVG/text.html#DominantBaselineProperty

The current rendering in Firefox:

<img width="101" alt="screen shot 2017-02-18 at 13 16 18" src="https://cloud.githubusercontent.com/assets/566719/23093470/86bbc614-f5dc-11e6-9902-3a3ddc9b30cf.png">
