### PR TITLE
Fix dead link to Node documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # stability-badges [![Flattr this!](https://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=hughskennedy&url=http://github.com/badges/stability-badges&title=stability-badges&description=badges/stability-badges%20on%20GitHub&language=en_GB&tags=flattr,github,javascript&category=software) #
 
 A set of SVG badges to mark your modules with the
-[Node stability index](http://nodejs.org/api/documentation.html#documentation_stability_index).
+[Node stability index](https://nodejs.org/docs/latest-v0.12.x/api/documentation.html).
 
 ### Stability: 0 - Deprecated ###
 


### PR DESCRIPTION
Node abandoned the stability index as defined here in version 4,
so the link in README should go to 0.12.x documentation.